### PR TITLE
fix partial argument matching and bfcremove error

### DIFF
--- a/R/biomaRt.R
+++ b/R/biomaRt.R
@@ -134,7 +134,7 @@ listMarts <- function( mart = NULL, host="https://www.ensembl.org", path="/bioma
     index = 1
     
     # if(host != "www.biomart.org" || archive){
-        for(i in seq(len=xmlSize(registry))){
+        for(i in seq(length.out=xmlSize(registry))){
             if(xmlName(registry[[i]])=="MartURLLocation"){  
                 if(xmlGetAttr(registry[[i]],"visible") == 1){
                     if(!is.null(xmlGetAttr(registry[[i]],"name"))) marts$biomart[index] = as.character(xmlGetAttr(registry[[i]],"name"))

--- a/R/ensembl.R
+++ b/R/ensembl.R
@@ -102,7 +102,7 @@ listEnsemblArchives <- function(https) {
         if(Sys.time() - as.POSIXct(cache_entry$create_time) < 7) {
             use_cached_version <- TRUE
         } else {
-            bfcremove(cache_entry$rid)
+            bfcremove(bfc, cache_entry$rid)
         }
     }
     


### PR DESCRIPTION
Hi Mike, @grimbough 
This fixes a couple of minor issues in the package. 
Note. It affects downstream packages, e.g., [`GenomicFeatures`](https://bioconductor.org/checkResults/devel/bioc-LATEST/GenomicFeatures/nebbiolo2-checksrc.html) with the error:

```r
> mart <- useEnsembl(biomart="ENSEMBL_MART_ENSEMBL", host="https://www.ensembl.org")
Error in (function (classes, fdef, mtable)  : 
  unable to find an inherited method for function ‘bfcremove’ for signature ‘"character"’
Calls: useEnsembl -> .listEnsembl -> bfcremove -> <Anonymous>
```

Thanks!
Best,
Marcel