### PR TITLE
Remove duplicated definition of .getEnsemblSSL()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: biomaRt
 Title: Interface to BioMart databases (i.e. Ensembl)
-Version: 2.65.1
+Version: 2.65.2
 Authors@R: c(
     person("Steffen", "Durinck", , "biomartdev@gmail.com", role = "aut"),
     person("Wolfgang", "Huber", role = "aut"),

--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,8 @@ INTERNAL CHANGES
   o Coding style throughout the package has been harmonized using the air tool.
   Contributors using RStudio, Positron or VS Code should have their code styled
   automatically on save.
+  o A duplicated definition of the `.getEnsemblSSL()` internal function has been
+  removed.
 
 CHANGES IN VERSION 2.64.0
 -------------------------

--- a/R/ensembl.R
+++ b/R/ensembl.R
@@ -1,17 +1,5 @@
 ## location of Ensembl specific functions
 
-.getEnsemblSSL <- function() {
-  cache <- .biomartCacheLocation()
-  bfc <- BiocFileCache::BiocFileCache(cache, ask = FALSE)
-  if (.checkInCache(bfc, hash = "ensembl-ssl-settings-httr2")) {
-    ensembl_config <- .readFromCache(bfc, "ensembl-ssl-settings-httr2")
-  } else {
-    ensembl_config <- .checkEnsemblSSL()
-    .addToCache(bfc, ensembl_config, hash = "ensembl-ssl-settings-httr2")
-  }
-  return(ensembl_config)
-}
-
 .checkArchiveList <- function(https = TRUE, http_config = list()) {
   ## determine if a cached version exists and if it's less than one week old
   cache <- .biomartCacheLocation()
@@ -311,7 +299,8 @@ useEnsembl <- function(
     )
   }
 
-  biomart <- switch(tolower(biomart),
+  biomart <- switch(
+    tolower(biomart),
     "ensembl" = "ENSEMBL_MART_ENSEMBL",
     "genes" = "ENSEMBL_MART_ENSEMBL",
     "snp" = "ENSEMBL_MART_SNP",


### PR DESCRIPTION
Fix #127 