### PR TITLE
Recognize ENSEMBL_MART_ENSEMBL as ensembl in martCheck()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: biomaRt
 Title: Interface to BioMart databases (i.e. Ensembl)
-Version: 2.65.4
+Version: 2.65.5
 Authors@R: c(
     person("Steffen", "Durinck", , "biomartdev@gmail.com", role = "aut"),
     person("Wolfgang", "Huber", role = "aut"),

--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,10 @@ BUG FIXES
 
   o This package now explicitly depends on R >= 4.0.0. This was effectively
   already the case since version 2.48 but not explicitly documented.
+  o `getGene()` no longer errors with "This function only works when used with
+  the ensembl BioMart.", that was always returned, even when using the ensembl
+  BioMart. This bug was introduced in version 2.27.1 (Bioconductor 3.3).
+  Thanks to [Tobias Hoch](https://github.com/toobiwankenobi) for the report.
 
 INTERNAL CHANGES
 

--- a/R/ensembl_wrappers.R
+++ b/R/ensembl_wrappers.R
@@ -61,7 +61,7 @@ checkWrapperArgs <- function(id, type, mart) {
 #'
 #' @export
 getGene <- function(id, type, mart) {
-  martCheck(mart, "ensembl")
+  martCheck(mart, c("ensembl", "ENSEMBL_MART_ENSEMBL"))
   checkWrapperArgs(id, type, mart)
   symbolAttrib <- switch(
     strsplit(martDataset(mart), "_", fixed = TRUE, useBytes = TRUE)[[1]][1],

--- a/tests/testthat/test-getGene.R
+++ b/tests/testthat/test-getGene.R
@@ -1,0 +1,9 @@
+test_that("getGene() recognizes new ensembl name as ensembl", {
+  # see https://github.com/Huber-group-EMBL/biomaRt/issues/122
+  mart <- useMart("ensembl", dataset = "hsapiens_gene_ensembl")
+
+  expect_no_error(
+    g <- getGene(id = "1939_at", type = "affy_hg_u95av2", mart = mart)
+  )
+  expect_identical(nrow(g), 1L)
+})


### PR DESCRIPTION
Should the examples & vignette also be updated to use `"ENSEMBL_MART_ENSEMBL"` as the default rather than `"ensembl"`?

The docs state to pick an option from `listMarts()`, which returns:

``` r
biomaRt::listMarts()
#>                biomart                version
#> 1 ENSEMBL_MART_ENSEMBL      Ensembl Genes 114
#> 2   ENSEMBL_MART_MOUSE      Mouse strains 114
#> 3     ENSEMBL_MART_SNP  Ensembl Variation 114
#> 4 ENSEMBL_MART_FUNCGEN Ensembl Regulation 114
```

<sup>Created on 2025-08-22 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

Before merging:

- [x] Add test
- [x] Update NEWS
- [x] Bump patch number