### PR TITLE
Ensure T/F characters are not converted to logicals

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: biomaRt
 Title: Interface to BioMart databases (i.e. Ensembl)
-Version: 2.65.14
+Version: 2.65.15
 Authors@R: c(
     person("Steffen", "Durinck", , "biomartdev@gmail.com", role = "aut"),
     person("Wolfgang", "Huber", role = "aut"),

--- a/NEWS
+++ b/NEWS
@@ -23,6 +23,10 @@ BUG FIXES
   o This package now explicitly depends on R >= 4.1.0. This was effectively
   already the case since version 2.58, in line with Bioconductor policy, but
   not explicitly documented in `DESCRIPTION`.
+  o `getBM()` no longer silently convert alleles "T" and "F" to logical `TRUE`
+  and `FALSE`. This rarely happened when a single allele, coincidentally named
+  "T" or "F", was returned in a column. Thanks to
+  [Sina Rüeger](https://github.com/sinarueeger) for the report.
 
 INTERNAL CHANGES
 

--- a/R/utilityFunctions.R
+++ b/R/utilityFunctions.R
@@ -299,6 +299,7 @@
       header = TRUE,
       quote = quote,
       comment.char = "",
+      tryLogical = FALSE,
       stringsAsFactors = FALSE,
       check.names = FALSE
     ),

--- a/tests/testthat/_snaps/getBM.md
+++ b/tests/testthat/_snaps/getBM.md
@@ -1,0 +1,9 @@
+# getBM doesn't convert T/F alleles into TRUE/FALSE
+
+    Code
+      getBM(attributes = c("refsnp_id", "minor_allele"), filters = c("chr_name",
+        "start", "end"), values = list(8, 35127386, 35127386), mart = snp_ensembl)
+    Output
+        refsnp_id minor_allele
+      1 rs1528723            T
+

--- a/tests/testthat/test_getBM.R
+++ b/tests/testthat/test_getBM.R
@@ -66,3 +66,27 @@ test_that("getBM returns sensible things", {
     "Argument 'values' should not be used when argument 'filters' is a list and will be ignored"
   )
 })
+
+test_that("getBM doesn't convert T/F alleles into TRUE/FALSE", {
+  skip_if_not_installed("mockery")
+
+  # Example from https://github.com/Huber-group-EMBL/biomaRt/issues/12
+  mockery::stub(
+    getBM,
+    ".submitQueryXML",
+    "Variant name\tMinor allele (ALL)\nrs1528723\tT\n"
+  )
+  snp_ensembl <- useEnsembl(
+    biomart = "snp",
+    dataset = "hsapiens_snp",
+    GRCh = 37
+  )
+  expect_snapshot(
+    getBM(
+      attributes = c("refsnp_id", "minor_allele"),
+      filters = c("chr_name", "start", "end"),
+      values = list(8, 35127386, 35127386),
+      mart = snp_ensembl
+    )
+  )
+})


### PR DESCRIPTION
Fix #12

- [x] Add test
- [x] Add NEWS
- [x] Bump version

This has a quite lighter footprint than keeping everything as character, which Mike mentioned in #12 would be a problem. I need to investigate if the change proposed here would have side effects as well.

The question is really whether we expect logical columns in `getBM()` output.