### PR TITLE
Make exportFASTA() faster

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: biomaRt
 Title: Interface to BioMart databases (i.e. Ensembl)
-Version: 2.65.10
+Version: 2.65.11
 Authors@R: c(
     person("Steffen", "Durinck", , "biomartdev@gmail.com", role = "aut"),
     person("Wolfgang", "Huber", role = "aut"),

--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,7 @@ USER VISIBLE CHANGES
 
   o This package documentation is now available as a pkgdown website at
   https://huber-group-embl.github.io/biomaRt/.
+  o The `exportFASTA()` function is now roughly 5x faster.
 
 BUG FIXES
 

--- a/R/biomaRt.R
+++ b/R/biomaRt.R
@@ -1422,13 +1422,13 @@ getLDS <- function(
 
 #' Exports getSequence results to FASTA format
 #'
-#' Exports getSequence results to FASTA format
-#'
-#'
 #' @param sequences A data.frame that was the output of the [getSequence()]
 #' function
 #' @param file File to which you want to write the data
+#'
 #' @author Steffen Durinck
+#' @author Hugo Gruson
+#'
 #' @keywords methods
 #'
 #' @examplesIf interactive()
@@ -1452,34 +1452,24 @@ exportFASTA <- function(sequences, file) {
   if (missing(file)) {
     stop("Please provide filename to write to")
   }
-  if (length(sequences[1, ]) == 2) {
-    for (i in seq_along(sequences[, 2])) {
-      cat(
-        paste0(">", sequences[i, 2], "\n"),
-        file = file,
-        append = TRUE
-      )
-      cat(as.character(sequences[i, 1]), file = file, append = TRUE)
-      cat("\n\n", file = file, append = TRUE)
-    }
+  if (ncol(sequences) == 2) {
+    writeLines(
+      sprintf(">%s\n%s", sequences[, 2], sequences[, 1]),
+      file,
+      sep = "\n\n"
+    )
   } else {
-    for (i in seq_along(sequences[, 2])) {
-      cat(
-        paste0(
-          ">chromosome_",
-          sequences[i, 1],
-          "_start_",
-          sequences[i, 2],
-          "_end_",
-          sequences[i, 3],
-          "\n"
-        ),
-        file = file,
-        append = TRUE
-      )
-      cat(as.character(sequences[i, 4]), file = file, append = TRUE)
-      cat("\n\n", file = file, append = TRUE)
-    }
+    writeLines(
+      sprintf(
+        ">chromosome_%s_start_%s_end_%s\n%s",
+        sequences[, 1],
+        sequences[, 2],
+        sequences[, 3],
+        sequences[, 4]
+      ),
+      file,
+      sep = "\n\n"
+    )
   }
 }
 

--- a/man/exportFASTA.Rd
+++ b/man/exportFASTA.Rd
@@ -30,5 +30,7 @@ exportFASTA(seq, file = "test.fasta")
 }
 \author{
 Steffen Durinck
+
+Hugo Gruson
 }
 \keyword{methods}

--- a/tests/testthat/_snaps/exportFASTA.md
+++ b/tests/testthat/_snaps/exportFASTA.md
@@ -1,0 +1,24 @@
+# exportFASTA() on gene-sequence data.frame
+
+    Code
+      exportFASTA(test_df, stdout())
+    Output
+      >gene1
+      ATCGATCGATCGATCGATCGATCGATCGATCGATCGATCG
+      
+      >gene2
+      GCTAGCTAGCTAGCTAGCTAGCTAGCTAGCTAGCTAGCTA
+      
+
+# exportFASTA() on 4 columns data
+
+    Code
+      exportFASTA(test_df, stdout())
+    Output
+      >chromosome_chr1_start_1_end_41
+      ATCGATCGATCGATCGATCGATCGATCGATCGATCGATCG
+      
+      >chromosome_chr1_start_55_end_95
+      GCTAGCTAGCTAGCTAGCTAGCTAGCTAGCTAGCTAGCTA
+      
+

--- a/tests/testthat/test-exportFASTA.R
+++ b/tests/testthat/test-exportFASTA.R
@@ -1,0 +1,19 @@
+test_that("exportFASTA() on gene-sequence data.frame", {
+  test_df <- data.frame(
+    sequence = c(strrep("ATCG", 10), strrep("GCTA", 10)),
+    gene = c("gene1", "gene2")
+  )
+
+  expect_snapshot(exportFASTA(test_df, stdout()))
+})
+
+test_that("exportFASTA() on 4 columns data", {
+  test_df <- data.frame(
+    chromosome = c("chr1", "chr1"),
+    start = c(1, 55),
+    end = c(1, 55) + 40,
+    sequence = c(strrep("ATCG", 10), strrep("GCTA", 10))
+  )
+
+  expect_snapshot(exportFASTA(test_df, stdout()))
+})


### PR DESCRIPTION
``` r
seq <- data.frame(
  name = paste("seq", 1:20),
  sequence = replicate(
    paste(sample(c("A", "T", "C", "G"), 1e4, replace = TRUE), collapse = ""),
    n = 20
  )
)

library(biomaRt)

microbenchmark::microbenchmark(
  exportFASTA_old(seq, nullfile()),
  exportFASTA_new(seq, nullfile()),
  times = 1e3
)
#> Unit: microseconds
#>                              expr      min       lq      mean    median
#>  exportFASTA_old(seq, nullfile()) 2327.360 2778.862 3370.8440 3163.8060
#>  exportFASTA_new(seq, nullfile())  497.375  534.036  679.8878  657.1005
#>        uq       max neval cld
#>  3652.604 26281.660  1000  a 
#>   745.850  2116.238  1000   b
```

<sup>Created on 2025-09-17 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>